### PR TITLE
Loading textcomp package overrides user changes to options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# use glob syntax.
-syntax: glob
-
 # Extracted files
 *.cfg
 *.sty


### PR DESCRIPTION
[Issue edited entirely: number used by a third-party before migration was complete]

Title covers it:

```
\documentclass{article}
\usepackage{siunitx,textcomp}
\sisetup{text-degree = a}
\begin{document}
\SI{10}{\degree}
\end{document} 
```
