### PR TITLE
Allow input unit with prefix and \per in exponent-to-prefix

### DIFF
--- a/siunitx.dtx
+++ b/siunitx.dtx
@@ -9384,6 +9384,11 @@ This work consists of the file  siunitx.dtx
         \prop_get:NnNT \l_@@_number_in_prop { exponent-sign }
           \l_@@_tmpb_tl
           { \tl_put_left:NV \l_@@_tmpa_tl \l_@@_tmpb_tl }
+        \prop_if_in:NnT \l_@@_unit_prop { per-1 }
+          {
+            \tl_set:Nx \l_@@_tmpa_tl
+              { \int_eval:n { - \l_@@_tmpa_tl } }
+          }
         \prop_get:NnNT \l_@@_unit_prop { prefix-1 } \l_@@_tmpb_tl
           {
             \prop_remove:Nn \l_@@_unit_prop { prefix-1 }
@@ -9397,11 +9402,6 @@ This work consists of the file  siunitx.dtx
           {
             \tl_set:Nx \l_@@_tmpa_tl
               { \int_eval:n { \l_@@_tmpa_tl / \l_@@_tmpb_tl } }
-          }
-        \prop_if_in:NnT \l_@@_unit_prop { per-1 }
-          {
-            \tl_set:Nx \l_@@_tmpa_tl
-              { \int_eval:n { - \l_@@_tmpa_tl } }
           }
         \prop_get:NVNTF \l_@@_prefix_reverse_prop \l_@@_tmpa_tl
           \l_@@_tmpb_tl


### PR DESCRIPTION
follow-up on #283

This should fix the following issue:
```
\documentclass{standalone}

\usepackage{siunitx}

\begin{document}
\SI[scientific-notation = engineering, exponent-to-prefix]{1e3}{\per\micro\second}
\end{document}
```
results in 1 ks-1 instead of 1 ns-1