### PR TITLE
Use correct name for boolean

### DIFF
--- a/siunitx.dtx
+++ b/siunitx.dtx
@@ -10906,7 +10906,7 @@ This work consists of the file  siunitx.dtx
 \cs_new_protected:Npn \@@_angle_direct_aux_i:nnn #1#2 {
   \tl_if_empty:nTF {#2}
     {
-      \bool_if:NTF \l_@@_angle_minte_zero_bool
+      \bool_if:NTF \l_@@_angle_minute_zero_bool
         { \@@_angle_direct_aux_ii:nnn {#1} { 0 } }
         { \@@_angle_direct_aux_ii:nnn {#1} { } }
     }


### PR DESCRIPTION
The name was changed in f03a70724cf9e3e5044b3fc2f64a16ea9224ff89

Some recent expl3 changes made this issue crop up. For example, the following code silently worked before but recognized `\l__siunitx_angle_minte_zero_bool` as an undefined control sequence sometime in the last few days.

```latex
\documentclass{article}

\usepackage{siunitx}

\begin{document}

\ang[parse-numbers = false]{\sqrt{2}}

\end{document}
```