### PR TITLE
Fix section about base units

### DIFF
--- a/siunitx.tex
+++ b/siunitx.tex
@@ -2836,13 +2836,11 @@ to make implementing the rules (relatively) easy.
 
 \subsection{Units}
 
-There are seven base \acro{SI} units, listed in Section~\ref{tab:unit:base}.
-Apart from the kilogram, these are defined in terms of a measurable physical
-quantity needing the definition alone.\footnote{Some base units need others
-defined first; there is therefore a required order of definition.} The base
-units have been chosen such that all physical quantities can be expressed using
-an appropriative combination of these units, needing no others and with no
-redundancy.
+There are seven base \acro{SI} units, listed in Section~\ref{tab:unit:base}.%
+\footnote{Some base units need others defined first; there is therefore a
+required order of definition.} The base units have been chosen such that all
+physical quantities can be expressed using an appropriative combination of
+these units, needing no others and with no redundancy.
 
 All other units within the \acro{SI} system are regarded as \enquote{derived}
 from the seven base units. At the most basic, all other SI units can be


### PR DESCRIPTION
This section currently still states that the kilogram
is defined base on the international prototype.
However this was change and is not true anymore.

In this commit said sentence is just removed.

fixes #382 