### PR TITLE
Add link to ctan

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ combination is clear. In particular, the SI units system lays
 down a consistent set of units with rules on how these are to be
 used. However, different countries and publishers have differing
 conventions on the exact appearance of numbers (and units). The
-`siunitx` package provides a set of tools for authors to typeset
+[`siunitx`](https://ctan.org/pkg/siunitx) package provides a set of tools for authors to typeset
 quantities in a consistent way. The package has an extended set
 of configuration options which make it possible to follow
 varying typographic conventions with the same input syntax. The


### PR DESCRIPTION
Quick hack to offer link to CTAN.

The alternative would be adding a badge as follows:

![grafik](https://user-images.githubusercontent.com/1366654/127785374-a92eab32-6451-4c67-bddb-2b64f9c762ed.png)

```markdown
[![CTAN](https://img.shields.io/badge/CTAN-siunitx-blue.svg?style=flat-square)](https://ctan.org/pkg/siunitx)
```