### PR TITLE
Fix typo \DescribeOption{uncertainty-*}

### DIFF
--- a/siunitx.tex
+++ b/siunitx.tex
@@ -1660,7 +1660,7 @@ stored will be used in place of the normal product and base combination.
   \num[output-exponent-marker = \mathrm{E}]{1e2}
 \end{LaTeXdemo}
 
-\DescribeOption{uncertainty-separator}
+\DescribeOption{uncertainty-mode}
 \DescribeOption{output-open-uncertainty}
 \DescribeOption{output-close-uncertainty}
 \DescribeOption{uncertainty-separator}


### PR DESCRIPTION
Found this typo while browsing the documentation.

The `uncertainty-separator` was listed twice, `uncertainty-mode` was missing