### PR TITLE
Add Portuguese and Brazilian translations

### DIFF
--- a/.github/tl_packages
+++ b/.github/tl_packages
@@ -24,6 +24,7 @@ babel-french
 babel-german
 babel-polish
 babel-spanish
+babel-portuges
 beamer
 bidi
 booktabs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
   [\#596](https://github.com/josephwright/siunitx/issues/596))
 - Unit abbreviation `\nW` (see issue
   [\#596](https://github.com/josephwright/siunitx/issues/596))
+- Brazilian and Portuguese translations for lists and ranges (see issue
+  [\#514](https://github.com/josephwright/siunitx/issues/514))
 
 ### Changed
 - Issue an error if the `units` package is loaded

--- a/siunitx-locale.dtx
+++ b/siunitx-locale.dtx
@@ -148,15 +148,18 @@
 \file_if_exist:nT { translations.sty }
   {
     \RequirePackage { translations }
-    \DeclareTranslation { Catalan } { and } { i }
-    \DeclareTranslation { Slovene } { and } { in }
-    \DeclareTranslation { Catalan } { to~(numerical~range) } { a }
-    \DeclareTranslation { English } { to~(numerical~range) } { to }
-    \DeclareTranslation { French }  { to~(numerical~range) } { à }
-    \DeclareTranslation { German }  { to~(numerical~range) } { bis }
-    \DeclareTranslation { Polish }  { to~(numerical~range) } { do }
-    \DeclareTranslation { Slovene } { to~(numerical~range) } { do }
-    \DeclareTranslation { Spanish } { to~(numerical~range) } { a }
+    \DeclareTranslation { Catalan }    { and } { i }
+    \DeclareTranslation { Slovene }    { and } { in }
+    \DeclareTranslation { Portuguese } { and } { e }
+    \DeclareTranslation { Catalan }    { to~(numerical~range) } { a }
+    \DeclareTranslation { English }    { to~(numerical~range) } { to }
+    \DeclareTranslation { French }     { to~(numerical~range) } { à }
+    \DeclareTranslation { German }     { to~(numerical~range) } { bis }
+    \DeclareTranslation { Polish }     { to~(numerical~range) } { do }
+    \DeclareTranslation { Slovene }    { to~(numerical~range) } { do }
+    \DeclareTranslation { Spanish }    { to~(numerical~range) } { a }
+    \DeclareTranslation { Brazilian }  { to~(numerical~range) } { a }
+    \DeclareTranslation { Portuguese } { to~(numerical~range) } { a }
     \keys_set:nn { siunitx }
       {
         list-final-separator =

--- a/siunitx-locale.dtx
+++ b/siunitx-locale.dtx
@@ -142,7 +142,7 @@
 %
 % \subsection{Localisation}
 %
-% Localisation makes use of the \pkg{translator} package. This only happens
+% Localisation makes use of the \pkg{translations} package. This only happens
 % if it is available, and is transparent to the user.
 %    \begin{macrocode}
 \file_if_exist:nT { translations.sty }

--- a/siunitx.tex
+++ b/siunitx.tex
@@ -79,7 +79,7 @@ for those people who are interested.
 }
 
 % For demos
-\usepackage[french,german,polish,spanish,UKenglish]{babel}
+\usepackage[portuguese,brazilian,catalan,french,german,polish,spanish,UKenglish]{babel}
 \AtBeginDocument{\shorthandoff{:<>}}
 \usepackage{translations}
 \usepackage{cancel}
@@ -3180,11 +3180,10 @@ unit which remains accepted.
 
 \section{Localisation}
 
-The \pkg{translations} package provides a structured framework for localisation
-of words and phrases, and is part of the larger \pkg{beamer} bundle. The
-\pkg{translations} package provides the \cs{translate} macro, which will provide
-appropriate translations based on the current \pkg{babel} or \pkg{polyglossia}
-language setting.
+The \pkg{translations} package provides a structured framework for
+localisation of words and phrases. In particular, it offers the
+\cs{GetTranslation} macro, which will provide appropriate translations based
+on the current \pkg{babel} or \pkg{polyglossia} language setting.
 
 If \pkg{translations} is available, \pkg{siunitx} will load it and alter the
 standard settings for the \opt{list-final-separator} and \opt{range-phrase}
@@ -3196,9 +3195,10 @@ options to read:
     range-phrase         = { \GetTranslation{to (numerical range)} },
   }
 \end{LaTeXdemo}
-If the current language is known to the \pkg{translator} package then the
+If the current language is known to the \pkg{translations} package then the
 result will be localised text. The preamble for this manual loads English,
-French, German, Polish and Spanish as options, and also loads the \pkg{babel} package:
+French, German, Polish, Spanish, Catalan, Portuguese and Brazilian as options,
+and also loads the \pkg{babel} package:
 \begin{LaTeXdemo}
   % In English by default
   \numlist{1;2;3} \\
@@ -3213,6 +3213,15 @@ French, German, Polish and Spanish as options, and also loads the \pkg{babel} pa
   \numlist{1;2;3} \\
   \numrange{1}{10} \\
   \selectlanguage{spanish}%
+  \numlist{1;2;3} \\
+  \numrange{1}{10} \\
+  \selectlanguage{catalan}%
+  \numlist{1;2;3} \\
+  \numrange{1}{10} \\
+  \selectlanguage{portuguese}%
+  \numlist{1;2;3} \\
+  \numrange{1}{10} \\
+  \selectlanguage{brazilian}%
   \numlist{1;2;3} \\
   \numrange{1}{10}
 \end{LaTeXdemo}

--- a/testfiles/siunitx-locale.luatex.tlg
+++ b/testfiles/siunitx-locale.luatex.tlg
@@ -4,6 +4,76 @@ Don't change this file in any respect.
 TEST 1: Translated strings
 ============================================================
 > \box...=
+\hbox(6.44444+1.93)x32.21005, direction TLT
+.\mathon
+.\OT1/cmr/m/n/10 1
+.\mathoff
+.\TU/lmr/m/n/10 ,
+.\glue(\spaceskip) 3.33 plus 2.08124 minus 0.888
+.\mathon
+.\OT1/cmr/m/n/10 2
+.\mathoff
+.\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.\hbox(4.48+0.11)x4.44, direction TLT
+..\TU/lmr/m/n/10 e
+.\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.\mathon
+.\OT1/cmr/m/n/10 3
+.\mathoff
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
+\hbox(6.44444+0.11)x21.66003, direction TLT
+.\mathon
+.\OT1/cmr/m/n/10 1
+.\mathoff
+.\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.\hbox(4.48+0.11)x5.0, direction TLT
+..\TU/lmr/m/n/10 a
+.\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.\mathon
+.\OT1/cmr/m/n/10 2
+.\mathoff
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
+\hbox(6.44444+1.93)x32.21005, direction TLT
+.\mathon
+.\OT1/cmr/m/n/10 1
+.\mathoff
+.\TU/lmr/m/n/10 ,
+.\glue(\spaceskip) 3.33 plus 2.08124 minus 0.888
+.\mathon
+.\OT1/cmr/m/n/10 2
+.\mathoff
+.\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.\hbox(4.48+0.11)x4.44, direction TLT
+..\TU/lmr/m/n/10 e
+.\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.\mathon
+.\OT1/cmr/m/n/10 3
+.\mathoff
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
+\hbox(6.44444+0.11)x21.66003, direction TLT
+.\mathon
+.\OT1/cmr/m/n/10 1
+.\mathoff
+.\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.\hbox(4.48+0.11)x5.0, direction TLT
+..\TU/lmr/m/n/10 a
+.\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.\mathon
+.\OT1/cmr/m/n/10 2
+.\mathoff
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
 \hbox(6.57+1.93)x30.55005, direction TLT
 .\mathon
 .\OT1/cmr/m/n/10 1

--- a/testfiles/siunitx-locale.lvt
+++ b/testfiles/siunitx-locale.lvt
@@ -10,7 +10,7 @@
 
 \usepackage{siunitx}
 
-\usepackage[catalan,english,french,german,polish,spanish]{babel}
+\usepackage[portuguese,brazilian,catalan,english,french,german,polish,spanish]{babel}
 
 \ExplSyntaxOn
 
@@ -49,7 +49,11 @@
 
 \TEST { Translated~strings }
   {
-    \clist_map_function:nN { catalan , english , french , german , polish , spanish }
+    \clist_map_function:nN
+      {
+        portuguese , brazilian , catalan , english , french , german ,
+        polish , spanish
+      }
       \test:n
   }
 

--- a/testfiles/siunitx-locale.tlg
+++ b/testfiles/siunitx-locale.tlg
@@ -4,6 +4,76 @@ Don't change this file in any respect.
 TEST 1: Translated strings
 ============================================================
 > \box...=
+\hbox(6.44444+1.94444)x32.22226
+.\mathon
+.\OT1/cmr/m/n/10 1
+.\mathoff
+.\OT1/cmr/m/n/10 ,
+.\glue 3.33333 plus 2.08331 minus 0.88889
+.\mathon
+.\OT1/cmr/m/n/10 2
+.\mathoff
+.\glue 3.33333 plus 1.66666 minus 1.11111
+.\hbox(4.30554+0.0)x4.44444
+..\OT1/cmr/m/n/10 e
+.\glue 3.33333 plus 1.66666 minus 1.11111
+.\mathon
+.\OT1/cmr/m/n/10 3
+.\mathoff
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
+\hbox(6.44444+0.0)x21.6667
+.\mathon
+.\OT1/cmr/m/n/10 1
+.\mathoff
+.\glue 3.33333 plus 1.66666 minus 1.11111
+.\hbox(4.30554+0.0)x5.00002
+..\OT1/cmr/m/n/10 a
+.\glue 3.33333 plus 1.66666 minus 1.11111
+.\mathon
+.\OT1/cmr/m/n/10 2
+.\mathoff
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
+\hbox(6.44444+1.94444)x32.22226
+.\mathon
+.\OT1/cmr/m/n/10 1
+.\mathoff
+.\OT1/cmr/m/n/10 ,
+.\glue 3.33333 plus 2.08331 minus 0.88889
+.\mathon
+.\OT1/cmr/m/n/10 2
+.\mathoff
+.\glue 3.33333 plus 1.66666 minus 1.11111
+.\hbox(4.30554+0.0)x4.44444
+..\OT1/cmr/m/n/10 e
+.\glue 3.33333 plus 1.66666 minus 1.11111
+.\mathon
+.\OT1/cmr/m/n/10 3
+.\mathoff
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
+\hbox(6.44444+0.0)x21.6667
+.\mathon
+.\OT1/cmr/m/n/10 1
+.\mathoff
+.\glue 3.33333 plus 1.66666 minus 1.11111
+.\hbox(4.30554+0.0)x5.00002
+..\OT1/cmr/m/n/10 a
+.\glue 3.33333 plus 1.66666 minus 1.11111
+.\mathon
+.\OT1/cmr/m/n/10 2
+.\mathoff
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
 \hbox(6.67859+1.94444)x30.5556
 .\mathon
 .\OT1/cmr/m/n/10 1

--- a/testfiles/siunitx-locale.xetex.tlg
+++ b/testfiles/siunitx-locale.xetex.tlg
@@ -4,6 +4,76 @@ Don't change this file in any respect.
 TEST 1: Translated strings
 ============================================================
 > \box...=
+\hbox(6.44444+1.92998)x32.21005
+.\mathon
+.\OT1/cmr/m/n/10 1
+.\mathoff
+.\TU/lmr/m/n/10 ,
+.\glue 3.33 plus 2.08124 minus 0.888
+.\mathon
+.\OT1/cmr/m/n/10 2
+.\mathoff
+.\glue 3.33 plus 1.665 minus 1.11
+.\hbox(4.48+0.10999)x4.44
+..\TU/lmr/m/n/10 e
+.\glue 3.33 plus 1.665 minus 1.11
+.\mathon
+.\OT1/cmr/m/n/10 3
+.\mathoff
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
+\hbox(6.44444+0.10999)x21.66003
+.\mathon
+.\OT1/cmr/m/n/10 1
+.\mathoff
+.\glue 3.33 plus 1.665 minus 1.11
+.\hbox(4.48+0.10999)x5.0
+..\TU/lmr/m/n/10 a
+.\glue 3.33 plus 1.665 minus 1.11
+.\mathon
+.\OT1/cmr/m/n/10 2
+.\mathoff
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
+\hbox(6.44444+1.92998)x32.21005
+.\mathon
+.\OT1/cmr/m/n/10 1
+.\mathoff
+.\TU/lmr/m/n/10 ,
+.\glue 3.33 plus 2.08124 minus 0.888
+.\mathon
+.\OT1/cmr/m/n/10 2
+.\mathoff
+.\glue 3.33 plus 1.665 minus 1.11
+.\hbox(4.48+0.10999)x4.44
+..\TU/lmr/m/n/10 e
+.\glue 3.33 plus 1.665 minus 1.11
+.\mathon
+.\OT1/cmr/m/n/10 3
+.\mathoff
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
+\hbox(6.44444+0.10999)x21.66003
+.\mathon
+.\OT1/cmr/m/n/10 1
+.\mathoff
+.\glue 3.33 plus 1.665 minus 1.11
+.\hbox(4.48+0.10999)x5.0
+..\TU/lmr/m/n/10 a
+.\glue 3.33 plus 1.665 minus 1.11
+.\mathon
+.\OT1/cmr/m/n/10 2
+.\mathoff
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
 \hbox(6.57+1.92998)x30.55005
 .\mathon
 .\OT1/cmr/m/n/10 1


### PR DESCRIPTION
Implements feature request at issue #514.

Adds `portuguese` and `brazilian` languages to regression tests at
siunitx-locale.lvt.