### PR TITLE
Small documentation typo

### DIFF
--- a/siunitx.tex
+++ b/siunitx.tex
@@ -1497,7 +1497,7 @@ scientific notation from the input
   \num[exponent-mode = fixed, fixed-exponent = 0]{1.23e4}
 \end{LaTeXdemo}
 \DescribeOption{exponent-thresholds}
-When the \opt{exponent-mode} is set to \meta{threshold}, values outside of a
+When the \opt{exponent-mode} is set to \opt{threshold}, values outside of a
 threshold range for the exponent are always printed in scientific form. Within
 the threshold, they are printed as-given in the input: typically this would be
 without an exponent. The threshold range itself is controlled by

--- a/siunitx.tex
+++ b/siunitx.tex
@@ -635,9 +635,9 @@ The spelling \enquote{\cs{deka}} is provided for US users as an alternative to
       Prefix & Command & Symbol & \multicolumn{1}{l@{}}{Power} \\
     \midrule
       \DescribePrefix{quecto} & -30 &
-      \DescribePrefix{deca}   &   1 \\      
+      \DescribePrefix{deca}   &   1 \\
       \DescribePrefix{ronto}  & -27 &
-      \DescribePrefix{hecto}  &   2 \\   
+      \DescribePrefix{hecto}  &   2 \\
       \DescribePrefix{yocto}  & -24 &
       \DescribePrefix{kilo}   &   3 \\
       \DescribePrefix{atto}   & -18 &
@@ -1524,7 +1524,7 @@ without an exponent. The threshold range itself is controlled by
       1     & 1     & 1     \\
       12    & 12    & 12    \\
       123   & 123   & 123   \\
-      1234  & 1234  & 1234  \\ 
+      1234  & 1234  & 1234  \\
     \bottomrule
     \end{tabular}
   \end{table}


### PR DESCRIPTION
`threshold` is an option value for `exponent-mode` and should receive the markup `\opt`, not `\meta`.

I also took the liberty of removing some trailing spaces, as my editor urged me to do.