### PR TITLE
Fix expansion test for S-column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- Add \textonly@unskip` to special tokens to cell content (see issue [\#737](https://github.com/josephwright/siunitx/issues/737))
+
 ## [v3.3.18] - 2024-06-14
 
 ### Fixed

--- a/siunitx-table.dtx
+++ b/siunitx-table.dtx
@@ -364,6 +364,7 @@
     \@@_collect_search:NnF #1
       {
         \unskip            { \@@_collect_loop: }
+        \textonly@unskip   { \@@_collect_loop: }
         \end               { \tabularnewline \end }
         \relax             { \@@_collect_relax:N #1 }
         \tabularnewline    { \tabularnewline }

--- a/testfiles/siunitx-table-header.lvt
+++ b/testfiles/siunitx-table-header.lvt
@@ -13,10 +13,14 @@
 % Set up math fonts
 \savebox0{$ \mathrm { a } \mathsf { b } \mathtt{ c } \mathbf { d } $ }
 
+% since \bar has been deprecated:
+\DeclareSIUnit{\bar}{bar}
+
 \START
 
 \begin{tabular}{@{}S@{}}
   {\begin{tabular}{@{}c@{}} a \\ b \end{tabular}} \\
+  {\unit{\bar}} \\
   123.456 \\
 \end{tabular}
 


### PR DESCRIPTION
As described in #737.

Not sure if using `\bar` as  deprecated unit is the best choice… but actually it's probably the easiest because of the different meaning outside the unit commands.