### PR TITLE
Improve `*-open/close-bracket` examples

### DIFF
--- a/siunitx.tex
+++ b/siunitx.tex
@@ -2182,25 +2182,25 @@ The option \opt{product-units} also offers the settings \opt{bracket-power} and
 \DescribeOption{product-open-bracket}
 \DescribeOption{range-close-bracket}
 \DescribeOption{range-open-bracket}
-The brackets used can be customised using the relevant \texttt{\dots-close-bracket}
-and \texttt{\dots-open-bracket} options.
+The brackets used can be customised using the relevant \texttt{\dots-open-bracket}
+and \texttt{\dots-close-bracket} options.
 \begin{LaTeXdemo}
   \sisetup{
     list-units         = bracket ,
-    list-open-bracket  = ( ,
-    list-close-bracket = )
+    list-open-bracket  = [ ,
+    list-close-bracket = ]
   }
-  \numlist{5e3;7e3;9e3;1e4} \\
+  \qtylist{5e3;7e3;9e3;1e4}{\second} \\
   \sisetup{
     product-units         = bracket ,
-    product-open-bracket  = ( ,
-    product-close-bracket = )
+    product-open-bracket  = \{ ,
+    product-close-bracket = \}
   }
-  \numproduct{5e3 x 7e3 x 9e3 x 1e4} \\
+  \qtyproduct{5e3 x 7e3 x 9e3 x 1e4}{\metre} \\
   \sisetup{
     range-units         = bracket ,
-    range-open-bracket  = ( ,
-    range-close-bracket = )
+    range-open-bracket  = \langle ,
+    range-close-bracket = \rangle
   }
   \qtyrange{2}{4}{\degreeCelsius}
 \end{LaTeXdemo}


### PR DESCRIPTION
The examples for `list-open/close-bracket` and `product-open/close-bracket` did not actually show the brackets, as no units were present. Also, all of the examples set `(` and `)` which is the default anyways.

I added units and used different brackets for the examples. I also swapped `open` and `close` in the introductory sentence so that they appear in that order.

I wasn't sure if this minor change warranted a changelog entry. If you want, I can add one.