### PR TITLE
Fix `tabularray` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Adjust `tabularray` support (see issue [\#883](https://github.com/josephwright/siunitx/issues/883))
+
 ## [v3.5.8] - 2026-09-03
 
 ### Fixed

--- a/siunitx-table.dtx
+++ b/siunitx-table.dtx
@@ -687,8 +687,8 @@
                    { \exp_not:N \gTblrLevelInt }
                    { \exp_not:N \g_tblr_level_int }
                     = 0
-                  { \@@_align_auxii:nn }
                   { \@@_align_auxiii:nn }
+                  { \@@_align_auxii:nn }
                     {#1} {#2}
               }
           }

--- a/testfiles/siunitx-pkg-tabularray.luatex.tlg
+++ b/testfiles/siunitx-pkg-tabularray.luatex.tlg
@@ -30,15 +30,13 @@ Overfull \hbox (15.0pt too wide) in paragraph at lines ...
 ........\vbox(8.39996+3.60004)x102.46667, direction TLT
 .........\hbox(8.39996+3.60004)x102.46667, direction TLT
 ..........\vbox(6.44444+3.60004)x102.46667, direction TLT
-...........\hbox(6.44444+0.0)x102.46667, glue set 79.68883fil, direction TLT
+...........\hbox(6.44444+0.0)x102.46667, glue set 79.68883fill, direction TLT
 ............\localpar
 .............\localinterlinepenalty=0
 .............\localbrokenpenalty=0
 .............\localleftbox=null
 .............\localrightbox=null
 ............\hbox(0.0+0.0)x0.0, direction TLT
-............\glue 0.0 plus -0.5fill
-............\kern0.0
 ............\glue 0.0 plus 1.0fill
 ............\kern0.0
 ............\hbox(0.0+0.0)x0.0, direction TLT
@@ -59,8 +57,6 @@ Overfull \hbox (15.0pt too wide) in paragraph at lines ...
 .............\glue 0.0 plus 1.0fil
 ............\glue 0.0
 ............\kern0.0
-............\glue 0.0 plus -0.5fill
-............\kern0.0
 ............\penalty 10000
 ............\glue(\parfillskip) 0.0 plus 1.0fil
 ............\glue(\rightskip) 0.0
@@ -79,15 +75,13 @@ Overfull \hbox (15.0pt too wide) in paragraph at lines ...
 ........\vbox(8.39996+3.60004)x102.46667, direction TLT
 .........\hbox(8.39996+3.60004)x102.46667, direction TLT
 ..........\vbox(6.44444+3.60004)x102.46667, direction TLT
-...........\hbox(6.44444+0.0)x102.46667, glue set 79.68883fil, direction TLT
+...........\hbox(6.44444+0.0)x102.46667, glue set 79.68883fill, direction TLT
 ............\localpar
 .............\localinterlinepenalty=0
 .............\localbrokenpenalty=0
 .............\localleftbox=null
 .............\localrightbox=null
 ............\hbox(0.0+0.0)x0.0, direction TLT
-............\glue 0.0 plus -0.5fill
-............\kern0.0
 ............\glue 0.0 plus 0.5fill
 ............\kern0.0
 ............\hbox(0.0+0.0)x0.0, direction TLT
@@ -108,8 +102,6 @@ Overfull \hbox (15.0pt too wide) in paragraph at lines ...
 .............\glue 0.0 plus 1.0fil
 ............\glue 0.0 plus 0.5fill
 ............\kern0.0
-............\glue 0.0 plus -0.5fill
-............\kern0.0
 ............\penalty 10000
 ............\glue(\parfillskip) 0.0 plus 1.0fil
 ............\glue(\rightskip) 0.0
@@ -128,15 +120,13 @@ Overfull \hbox (15.0pt too wide) in paragraph at lines ...
 ........\vbox(8.39996+3.60004)x102.46667, direction TLT
 .........\hbox(8.39996+3.60004)x102.46667, direction TLT
 ..........\vbox(6.44444+3.60004)x102.46667, direction TLT
-...........\hbox(6.44444+0.0)x102.46667, glue set 79.68883fil, direction TLT
+...........\hbox(6.44444+0.0)x102.46667, glue set 79.68883fill, direction TLT
 ............\localpar
 .............\localinterlinepenalty=0
 .............\localbrokenpenalty=0
 .............\localleftbox=null
 .............\localrightbox=null
 ............\hbox(0.0+0.0)x0.0, direction TLT
-............\glue 0.0 plus -0.5fill
-............\kern0.0
 ............\glue 0.0
 ............\kern0.0
 ............\hbox(0.0+0.0)x0.0, direction TLT
@@ -156,8 +146,6 @@ Overfull \hbox (15.0pt too wide) in paragraph at lines ...
 .............\glue 5.00002
 .............\glue 0.0 plus 1.0fil
 ............\glue 0.0 plus 1.0fill
-............\kern0.0
-............\glue 0.0 plus -0.5fill
 ............\kern0.0
 ............\penalty 10000
 ............\glue(\parfillskip) 0.0 plus 1.0fil
@@ -244,7 +232,7 @@ Completed box being shipped out [1]
 ....\pdfcolorstack 0 pop
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(550.0+0.0)x345.0, glue set 513.94513fil, direction TLT
+..\vbox(550.0+0.0)x345.0, glue set 476.94907fil, direction TLT
 ...\write-{}
 ...\glue(\topskip) 0.0
 ...\hbox(10.5+5.5)x345.0, direction TLT
@@ -271,15 +259,13 @@ Completed box being shipped out [1]
 ...........\vbox(8.39996+3.60004)x102.46667, direction TLT
 ............\hbox(8.39996+3.60004)x102.46667, direction TLT
 .............\vbox(6.44444+3.60004)x102.46667, direction TLT
-..............\hbox(6.44444+0.0)x102.46667, glue set 79.68883fil, direction TLT
+..............\hbox(6.44444+0.0)x102.46667, glue set 79.68883fill, direction TLT
 ...............\localpar
 ................\localinterlinepenalty=0
 ................\localbrokenpenalty=0
 ................\localleftbox=null
 ................\localrightbox=null
 ...............\hbox(0.0+0.0)x0.0, direction TLT
-...............\glue 0.0 plus -0.5fill
-...............\kern0.0
 ...............\glue 0.0 plus 1.0fill
 ...............\kern0.0
 ...............\hbox(0.0+0.0)x0.0, direction TLT
@@ -300,8 +286,6 @@ Completed box being shipped out [1]
 ................\glue 0.0 plus 1.0fil
 ...............\glue 0.0
 ...............\kern0.0
-...............\glue 0.0 plus -0.5fill
-...............\kern0.0
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0 plus 1.0fil
 ...............\glue(\rightskip) 0.0
@@ -320,15 +304,13 @@ Completed box being shipped out [1]
 ...........\vbox(8.39996+3.60004)x102.46667, direction TLT
 ............\hbox(8.39996+3.60004)x102.46667, direction TLT
 .............\vbox(6.44444+3.60004)x102.46667, direction TLT
-..............\hbox(6.44444+0.0)x102.46667, glue set 79.68883fil, direction TLT
+..............\hbox(6.44444+0.0)x102.46667, glue set 79.68883fill, direction TLT
 ...............\localpar
 ................\localinterlinepenalty=0
 ................\localbrokenpenalty=0
 ................\localleftbox=null
 ................\localrightbox=null
 ...............\hbox(0.0+0.0)x0.0, direction TLT
-...............\glue 0.0 plus -0.5fill
-...............\kern0.0
 ...............\glue 0.0 plus 0.5fill
 ...............\kern0.0
 ...............\hbox(0.0+0.0)x0.0, direction TLT
@@ -349,8 +331,6 @@ Completed box being shipped out [1]
 ................\glue 0.0 plus 1.0fil
 ...............\glue 0.0 plus 0.5fill
 ...............\kern0.0
-...............\glue 0.0 plus -0.5fill
-...............\kern0.0
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0 plus 1.0fil
 ...............\glue(\rightskip) 0.0
@@ -369,15 +349,13 @@ Completed box being shipped out [1]
 ...........\vbox(8.39996+3.60004)x102.46667, direction TLT
 ............\hbox(8.39996+3.60004)x102.46667, direction TLT
 .............\vbox(6.44444+3.60004)x102.46667, direction TLT
-..............\hbox(6.44444+0.0)x102.46667, glue set 79.68883fil, direction TLT
+..............\hbox(6.44444+0.0)x102.46667, glue set 79.68883fill, direction TLT
 ...............\localpar
 ................\localinterlinepenalty=0
 ................\localbrokenpenalty=0
 ................\localleftbox=null
 ................\localrightbox=null
 ...............\hbox(0.0+0.0)x0.0, direction TLT
-...............\glue 0.0 plus -0.5fill
-...............\kern0.0
 ...............\glue 0.0
 ...............\kern0.0
 ...............\hbox(0.0+0.0)x0.0, direction TLT
@@ -397,8 +375,6 @@ Completed box being shipped out [1]
 ................\glue 5.00002
 ................\glue 0.0 plus 1.0fil
 ...............\glue 0.0 plus 1.0fill
-...............\kern0.0
-...............\glue 0.0 plus -0.5fill
 ...............\kern0.0
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0 plus 1.0fil
@@ -488,10 +464,12 @@ Completed box being shipped out [1]
 ........\glue 0.0 plus 1.0fill
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
-.......\hbox(8.39996+3.60004)x68.11119, glue set 11.66666fill, direction TLT
+.......\hbox(8.39996+3.60004)x68.11119, glue set 23.33331fill, direction TLT
 ........\glue 6.0
 ........\rule(6.44444+*)x0.0
 ........\glue 0.0 plus 0.5fill
+........\kern0.0
+........\glue 0.0 plus -0.5fill
 ........\kern0.0
 ........\glue 0.0 plus 0.5fill
 ........\kern0.0
@@ -513,6 +491,8 @@ Completed box being shipped out [1]
 .........\glue 0.0 plus 1.0fil
 ........\glue 0.0 plus 0.5fill
 ........\kern0.0
+........\glue 0.0 plus -0.5fill
+........\kern0.0
 ........\glue 0.0 plus 0.5fill
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
@@ -531,6 +511,8 @@ Completed box being shipped out [1]
 ........\glue 6.0
 ........\rule(6.44444+*)x0.0
 ........\glue 0.0 plus 0.5fill
+........\kern0.0
+........\glue 0.0 plus -0.5fill
 ........\kern0.0
 ........\glue 0.0 plus 0.5fill
 ........\kern0.0
@@ -553,8 +535,139 @@ Completed box being shipped out [1]
 .........\glue 0.0 plus 1.0fil
 ........\glue 0.0 plus 0.5fill
 ........\kern0.0
+........\glue 0.0 plus -0.5fill
+........\kern0.0
 ........\glue 0.0 plus 0.5fill
 ........\glue 6.0
+.......\glue(\tabskip) 0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\lineskip) 1.0
+...\hbox(20.5+15.5)x345.0, glue set 246.0fil, direction TLT
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x15.0, direction TLT
+....\hbox(20.5+15.5)x84.0, direction TLT
+.....\vbox(20.5+15.5)x84.0, direction TLT
+......\hbox(8.39996+3.60004)x84.0, direction TLT
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x52.0, direction TLT
+........\rule(8.39996+3.60004)x0.0
+........\glue 6.0
+........\rule(0.4+*)x0.0
+........\hbox(0.4+0.0)x40.0, direction TLT
+.........\rule(0.4+0.0)x40.0
+........\glue 0.0 plus 1.0fill
+........\glue 6.0
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x32.0, direction TLT
+........\glue 6.0
+........\rule(0.4+*)x0.0
+........\glue 0.0 plus 1.0fill
+........\kern0.0
+........\hbox(0.4+0.0)x20.0, direction TLT
+.........\rule(0.4+0.0)x20.0
+........\glue 6.0
+.......\glue(\tabskip) 0.0
+......\glue(\lineskip) 0.0
+......\hbox(8.39996+3.60004)x84.0, direction TLT
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x52.0, glue set 44.22214fill, direction TLT
+........\rule(8.39996+3.60004)x0.0
+........\glue 6.0
+........\pdfcolorstack 0 push {0 0 1 0 k 0 0 1 0 K}
+........\kern-6.0
+........\leaders 39.77786 plus 1.0fill
+.........\rule(*+*)x0.4
+........\kern-6.0
+........\glue -27.77786 plus -1.0fill
+........\pdfcolorstack 0 pop
+........\rule(6.44444+*)x0.0
+........\glue 0.0 plus 0.5fill
+........\kern0.0
+........\glue 0.0 plus -0.5fill
+........\kern0.0
+........\glue 0.0 plus 0.5fill
+........\kern0.0
+........\hbox(0.0+0.0)x0.0, direction TLT
+.........\glue 0.0 plus 1.0fil
+........\hbox(6.44444+0.0)x20.00006, glue set 5.00002fil, direction TLT
+.........\glue 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fil
+.........\mathon
+.........\OT1/cmr/m/n/10 1
+.........\OT1/cmr/m/n/10 2
+.........\mathoff
+........\hbox(6.44444+0.0)x7.7778, direction TLT
+.........\mathon
+.........\OML/cmm/m/it/10 :
+.........\OT1/cmr/m/n/10 3
+.........\mathoff
+........\hbox(0.0+0.0)x0.0, direction TLT
+.........\glue 0.0
+.........\glue 0.0 plus 1.0fil
+........\glue 0.0 plus 0.5fill
+........\kern0.0
+........\glue 0.0 plus -0.5fill
+........\kern0.0
+........\glue 0.0 plus 0.5fill
+........\glue 6.0
+........\hbox(0.0+0.0)x0.0, direction TLT
+.......\glue(\tabskip) 0.0
+.......\hbox(0.0+0.0)x32.0, direction TLT
+.......\glue(\tabskip) 0.0
+......\glue(\lineskip) 0.0
+......\hbox(8.39996+3.60004)x84.0, direction TLT
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x52.0, glue set 44.22214fill, direction TLT
+........\rule(8.39996+3.60004)x0.0
+........\glue 6.0
+........\pdfcolorstack 0 push {0 0 1 0 k 0 0 1 0 K}
+........\kern-6.0
+........\leaders 39.77786 plus 1.0fill
+.........\rule(*+*)x0.4
+........\kern-6.0
+........\glue -27.77786 plus -1.0fill
+........\pdfcolorstack 0 pop
+........\rule(6.44444+*)x0.0
+........\glue 0.0 plus 0.5fill
+........\kern0.0
+........\glue 0.0 plus -0.5fill
+........\kern0.0
+........\glue 0.0 plus 0.5fill
+........\kern0.0
+........\hbox(0.0+0.0)x0.0, direction TLT
+.........\glue 0.0 plus 1.0fil
+........\hbox(6.44444+0.0)x20.00006, glue set 7.50003fil, direction TLT
+.........\glue 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fil
+.........\mathon
+.........\OT1/cmr/m/n/10 1
+.........\mathoff
+........\hbox(6.44444+0.0)x12.77782, direction TLT
+.........\mathon
+.........\OML/cmm/m/it/10 :
+.........\OT1/cmr/m/n/10 2
+.........\OT1/cmr/m/n/10 3
+.........\mathoff
+........\hbox(0.0+0.0)x-5.00002, direction TLT
+.........\glue -5.00002
+.........\glue 0.0 plus 1.0fil
+........\glue 0.0 plus 0.5fill
+........\kern0.0
+........\glue 0.0 plus -0.5fill
+........\kern0.0
+........\glue 0.0 plus 0.5fill
+........\glue 6.0
+........\hbox(0.0+0.0)x0.0, direction TLT
+.......\glue(\tabskip) 0.0
+.......\hbox(0.0+0.0)x32.0, direction TLT
 .......\glue(\tabskip) 0.0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil

--- a/testfiles/siunitx-pkg-tabularray.lvt
+++ b/testfiles/siunitx-pkg-tabularray.lvt
@@ -9,6 +9,7 @@
 \usepackage{siunitx}
 
 % Needed to force the issue
+\usepackage{color}
 \usepackage{colortbl}
 \usepackage{tabularray}
 \UseTblrLibrary{siunitx}
@@ -19,6 +20,7 @@
 
 \showoutput
 
+% issue TeXackers/tabularray#512
 \begin{tblr}{
     |
     X[si={table-alignment-mode=format,table-number-alignment=right}]
@@ -31,9 +33,17 @@
     1.1 & 2.2 & 3.3 \\
 \end{tblr}
 
-  \begin{tabular}{l S}
-	  a & 135.053 \\
-	  b & 0.32217
-  \end{tabular}
+% issue #760
+\begin{tabular}{l S}
+  a & 135.053 \\
+  b & 0.32217
+\end{tabular}
+
+% issue #883
+\begin{tabular}{l r}
+  \rule{40pt}{.4pt} & \rule{20pt}{.4pt} \\
+  \multicolumn{2}{c}{\cellcolor{yellow}\tablenum[table-format = 4.1]{12.3}} \\
+  \multicolumn{2}{c}{\cellcolor{yellow}\tablenum[table-format = 4.1]{1.23}}
+\end{tabular}
 
 \end{document}

--- a/testfiles/siunitx-pkg-tabularray.tlg
+++ b/testfiles/siunitx-pkg-tabularray.tlg
@@ -25,10 +25,8 @@ Overfull \hbox (15.0pt too wide) in paragraph at lines ...
 ........\vbox(8.39996+3.60004)x102.46667
 .........\hbox(8.39996+3.60004)x102.46667
 ..........\vbox(6.44444+3.60004)x102.46667
-...........\hbox(6.44444+0.0)x102.46667, glue set 79.68883fil
+...........\hbox(6.44444+0.0)x102.46667, glue set 79.68883fill
 ............\hbox(0.0+0.0)x0.0
-............\glue 0.0 plus -0.5fill
-............\kern 0.0
 ............\glue 0.0 plus 1.0fill
 ............\kern 0.0
 ............\hbox(0.0+0.0)x0.0
@@ -49,8 +47,6 @@ Overfull \hbox (15.0pt too wide) in paragraph at lines ...
 .............\glue 0.0 plus 1.0fil
 ............\glue 0.0
 ............\kern 0.0
-............\glue 0.0 plus -0.5fill
-............\kern 0.0
 ............\penalty 10000
 ............\glue(\parfillskip) 0.0 plus 1.0fil
 ............\glue(\rightskip) 0.0
@@ -69,10 +65,8 @@ Overfull \hbox (15.0pt too wide) in paragraph at lines ...
 ........\vbox(8.39996+3.60004)x102.46667
 .........\hbox(8.39996+3.60004)x102.46667
 ..........\vbox(6.44444+3.60004)x102.46667
-...........\hbox(6.44444+0.0)x102.46667, glue set 79.68883fil
+...........\hbox(6.44444+0.0)x102.46667, glue set 79.68883fill
 ............\hbox(0.0+0.0)x0.0
-............\glue 0.0 plus -0.5fill
-............\kern 0.0
 ............\glue 0.0 plus 0.5fill
 ............\kern 0.0
 ............\hbox(0.0+0.0)x0.0
@@ -93,8 +87,6 @@ Overfull \hbox (15.0pt too wide) in paragraph at lines ...
 .............\glue 0.0 plus 1.0fil
 ............\glue 0.0 plus 0.5fill
 ............\kern 0.0
-............\glue 0.0 plus -0.5fill
-............\kern 0.0
 ............\penalty 10000
 ............\glue(\parfillskip) 0.0 plus 1.0fil
 ............\glue(\rightskip) 0.0
@@ -113,10 +105,8 @@ Overfull \hbox (15.0pt too wide) in paragraph at lines ...
 ........\vbox(8.39996+3.60004)x102.46667
 .........\hbox(8.39996+3.60004)x102.46667
 ..........\vbox(6.44444+3.60004)x102.46667
-...........\hbox(6.44444+0.0)x102.46667, glue set 79.68883fil
+...........\hbox(6.44444+0.0)x102.46667, glue set 79.68883fill
 ............\hbox(0.0+0.0)x0.0
-............\glue 0.0 plus -0.5fill
-............\kern 0.0
 ............\glue 0.0
 ............\kern 0.0
 ............\hbox(0.0+0.0)x0.0
@@ -136,8 +126,6 @@ Overfull \hbox (15.0pt too wide) in paragraph at lines ...
 .............\glue 5.00002
 .............\glue 0.0 plus 1.0fil
 ............\glue 0.0 plus 1.0fill
-............\kern 0.0
-............\glue 0.0 plus -0.5fill
 ............\kern 0.0
 ............\penalty 10000
 ............\glue(\parfillskip) 0.0 plus 1.0fil
@@ -224,7 +212,7 @@ Completed box being shipped out [1]
 ....\pdfcolorstack 0 pop
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(550.0+0.0)x345.0, glue set 513.9451fil
+..\vbox(550.0+0.0)x345.0, glue set 476.94905fil
 ...\write-{}
 ...\glue(\topskip) 0.0
 ...\hbox(10.5+5.5)x345.0
@@ -246,10 +234,8 @@ Completed box being shipped out [1]
 ...........\vbox(8.39996+3.60004)x102.46667
 ............\hbox(8.39996+3.60004)x102.46667
 .............\vbox(6.44444+3.60004)x102.46667
-..............\hbox(6.44444+0.0)x102.46667, glue set 79.68883fil
+..............\hbox(6.44444+0.0)x102.46667, glue set 79.68883fill
 ...............\hbox(0.0+0.0)x0.0
-...............\glue 0.0 plus -0.5fill
-...............\kern 0.0
 ...............\glue 0.0 plus 1.0fill
 ...............\kern 0.0
 ...............\hbox(0.0+0.0)x0.0
@@ -270,8 +256,6 @@ Completed box being shipped out [1]
 ................\glue 0.0 plus 1.0fil
 ...............\glue 0.0
 ...............\kern 0.0
-...............\glue 0.0 plus -0.5fill
-...............\kern 0.0
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0 plus 1.0fil
 ...............\glue(\rightskip) 0.0
@@ -290,10 +274,8 @@ Completed box being shipped out [1]
 ...........\vbox(8.39996+3.60004)x102.46667
 ............\hbox(8.39996+3.60004)x102.46667
 .............\vbox(6.44444+3.60004)x102.46667
-..............\hbox(6.44444+0.0)x102.46667, glue set 79.68883fil
+..............\hbox(6.44444+0.0)x102.46667, glue set 79.68883fill
 ...............\hbox(0.0+0.0)x0.0
-...............\glue 0.0 plus -0.5fill
-...............\kern 0.0
 ...............\glue 0.0 plus 0.5fill
 ...............\kern 0.0
 ...............\hbox(0.0+0.0)x0.0
@@ -314,8 +296,6 @@ Completed box being shipped out [1]
 ................\glue 0.0 plus 1.0fil
 ...............\glue 0.0 plus 0.5fill
 ...............\kern 0.0
-...............\glue 0.0 plus -0.5fill
-...............\kern 0.0
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0 plus 1.0fil
 ...............\glue(\rightskip) 0.0
@@ -334,10 +314,8 @@ Completed box being shipped out [1]
 ...........\vbox(8.39996+3.60004)x102.46667
 ............\hbox(8.39996+3.60004)x102.46667
 .............\vbox(6.44444+3.60004)x102.46667
-..............\hbox(6.44444+0.0)x102.46667, glue set 79.68883fil
+..............\hbox(6.44444+0.0)x102.46667, glue set 79.68883fill
 ...............\hbox(0.0+0.0)x0.0
-...............\glue 0.0 plus -0.5fill
-...............\kern 0.0
 ...............\glue 0.0
 ...............\kern 0.0
 ...............\hbox(0.0+0.0)x0.0
@@ -357,8 +335,6 @@ Completed box being shipped out [1]
 ................\glue 5.00002
 ................\glue 0.0 plus 1.0fil
 ...............\glue 0.0 plus 1.0fill
-...............\kern 0.0
-...............\glue 0.0 plus -0.5fill
 ...............\kern 0.0
 ...............\penalty 10000
 ...............\glue(\parfillskip) 0.0 plus 1.0fil
@@ -443,10 +419,12 @@ Completed box being shipped out [1]
 ........\glue 0.0 plus 1.0fill
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
-.......\hbox(8.39996+3.60004)x68.11119, glue set 11.66666fill
+.......\hbox(8.39996+3.60004)x68.11119, glue set 23.33331fill
 ........\glue 6.0
 ........\rule(6.44444+*)x0.0
 ........\glue 0.0 plus 0.5fill
+........\kern 0.0
+........\glue 0.0 plus -0.5fill
 ........\kern 0.0
 ........\glue 0.0 plus 0.5fill
 ........\kern 0.0
@@ -468,6 +446,8 @@ Completed box being shipped out [1]
 .........\glue 0.0 plus 1.0fil
 ........\glue 0.0 plus 0.5fill
 ........\kern 0.0
+........\glue 0.0 plus -0.5fill
+........\kern 0.0
 ........\glue 0.0 plus 0.5fill
 ........\glue 6.0
 .......\glue(\tabskip) 0.0
@@ -486,6 +466,8 @@ Completed box being shipped out [1]
 ........\glue 6.0
 ........\rule(6.44444+*)x0.0
 ........\glue 0.0 plus 0.5fill
+........\kern 0.0
+........\glue 0.0 plus -0.5fill
 ........\kern 0.0
 ........\glue 0.0 plus 0.5fill
 ........\kern 0.0
@@ -508,8 +490,134 @@ Completed box being shipped out [1]
 .........\glue 0.0 plus 1.0fil
 ........\glue 0.0 plus 0.5fill
 ........\kern 0.0
+........\glue 0.0 plus -0.5fill
+........\kern 0.0
 ........\glue 0.0 plus 0.5fill
 ........\glue 6.0
+.......\glue(\tabskip) 0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\lineskip) 1.0
+...\hbox(20.5+15.5)x345.0, glue set 246.0fil
+....\hbox(0.0+0.0)x15.0
+....\hbox(20.5+15.5)x84.0
+.....\vbox(20.5+15.5)x84.0
+......\hbox(8.39996+3.60004)x84.0
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x52.0
+........\rule(8.39996+3.60004)x0.0
+........\glue 6.0
+........\rule(0.4+*)x0.0
+........\hbox(0.4+0.0)x40.0
+.........\rule(0.4+0.0)x40.0
+........\glue 0.0 plus 1.0fill
+........\glue 6.0
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x32.0
+........\glue 6.0
+........\rule(0.4+*)x0.0
+........\glue 0.0 plus 1.0fill
+........\kern 0.0
+........\hbox(0.4+0.0)x20.0
+.........\rule(0.4+0.0)x20.0
+........\glue 6.0
+.......\glue(\tabskip) 0.0
+......\glue(\lineskip) 0.0
+......\hbox(8.39996+3.60004)x84.0
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x52.0, glue set 44.22214fill
+........\rule(8.39996+3.60004)x0.0
+........\glue 6.0
+........\pdfcolorstack 0 push {0 0 1 0 k 0 0 1 0 K}
+........\kern -6.0
+........\leaders 39.77786 plus 1.0fill
+.........\rule(*+*)x0.4
+........\kern -6.0
+........\glue -27.77786 plus -1.0fill
+........\pdfcolorstack 0 pop
+........\rule(6.44444+*)x0.0
+........\glue 0.0 plus 0.5fill
+........\kern 0.0
+........\glue 0.0 plus -0.5fill
+........\kern 0.0
+........\glue 0.0 plus 0.5fill
+........\kern 0.0
+........\hbox(0.0+0.0)x0.0
+.........\glue 0.0 plus 1.0fil
+........\hbox(6.44444+0.0)x20.00006, glue set 5.00002fil
+.........\glue 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fil
+.........\mathon
+.........\OT1/cmr/m/n/10 1
+.........\OT1/cmr/m/n/10 2
+.........\mathoff
+........\hbox(6.44444+0.0)x7.7778
+.........\mathon
+.........\OML/cmm/m/it/10 :
+.........\OT1/cmr/m/n/10 3
+.........\mathoff
+........\hbox(0.0+0.0)x0.0
+.........\glue 0.0
+.........\glue 0.0 plus 1.0fil
+........\glue 0.0 plus 0.5fill
+........\kern 0.0
+........\glue 0.0 plus -0.5fill
+........\kern 0.0
+........\glue 0.0 plus 0.5fill
+........\glue 6.0
+........\hbox(0.0+0.0)x0.0
+.......\glue(\tabskip) 0.0
+.......\hbox(0.0+0.0)x32.0
+.......\glue(\tabskip) 0.0
+......\glue(\lineskip) 0.0
+......\hbox(8.39996+3.60004)x84.0
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x52.0, glue set 44.22214fill
+........\rule(8.39996+3.60004)x0.0
+........\glue 6.0
+........\pdfcolorstack 0 push {0 0 1 0 k 0 0 1 0 K}
+........\kern -6.0
+........\leaders 39.77786 plus 1.0fill
+.........\rule(*+*)x0.4
+........\kern -6.0
+........\glue -27.77786 plus -1.0fill
+........\pdfcolorstack 0 pop
+........\rule(6.44444+*)x0.0
+........\glue 0.0 plus 0.5fill
+........\kern 0.0
+........\glue 0.0 plus -0.5fill
+........\kern 0.0
+........\glue 0.0 plus 0.5fill
+........\kern 0.0
+........\hbox(0.0+0.0)x0.0
+.........\glue 0.0 plus 1.0fil
+........\hbox(6.44444+0.0)x20.00006, glue set 7.50003fil
+.........\glue 0.0 plus 1.0fil
+.........\glue 0.0 plus 1.0fil
+.........\mathon
+.........\OT1/cmr/m/n/10 1
+.........\mathoff
+........\hbox(6.44444+0.0)x12.77782
+.........\mathon
+.........\OML/cmm/m/it/10 :
+.........\OT1/cmr/m/n/10 2
+.........\OT1/cmr/m/n/10 3
+.........\mathoff
+........\hbox(0.0+0.0)x-5.00002
+.........\glue -5.00002
+.........\glue 0.0 plus 1.0fil
+........\glue 0.0 plus 0.5fill
+........\kern 0.0
+........\glue 0.0 plus -0.5fill
+........\kern 0.0
+........\glue 0.0 plus 0.5fill
+........\glue 6.0
+........\hbox(0.0+0.0)x0.0
+.......\glue(\tabskip) 0.0
+.......\hbox(0.0+0.0)x32.0
 .......\glue(\tabskip) 0.0
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil


### PR DESCRIPTION
Comparison of PDF output of `siunitx-pkg-tabularray.lvt` test:

Before

<img width="686" height="179" alt="image" src="https://github.com/user-attachments/assets/11492924-a37b-48e5-9d39-a7c7928b2225" />

After

<img width="681" height="169" alt="image" src="https://github.com/user-attachments/assets/4887329f-441b-433a-a13e-0a21c2da69bd" />

Fixes #883.